### PR TITLE
ci: add Python 3.13 to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

`pyproject.toml` declares Python 3.13 support in its classifiers, but the CI matrix only tests against 3.10, 3.11, and 3.12. A regression specific to 3.13 (stdlib behavior change, deprecation, etc.) would ship silently to users on the latest Python release.

## Fix

Add `"3.13"` to the matrix. One line change.

```yaml
python-version: ["3.10", "3.11", "3.12", "3.13"]
```