### PR TITLE
feat: add exclude_topics filter to trending_repos and find_mentor_repos

### DIFF
--- a/src/opencollab_mcp/models.py
+++ b/src/opencollab_mcp/models.py
@@ -40,6 +40,10 @@ class LanguageInput(BaseModel):
         description="Programming language (e.g. 'Python', 'TypeScript', 'Rust')",
         min_length=1,
     )
+    exclude_topics: list[str] | None = Field(
+    default=None,
+    description="Topics to exclude from results (e.g. ['machine-learning', 'pytorch'])",
+)
 
 
 class CompareInput(BaseModel):

--- a/src/opencollab_mcp/models.py
+++ b/src/opencollab_mcp/models.py
@@ -41,9 +41,9 @@ class LanguageInput(BaseModel):
         min_length=1,
     )
     exclude_topics: list[str] | None = Field(
-    default=None,
-    description="Topics to exclude from results (e.g. ['machine-learning', 'pytorch'])",
-)
+        default=None,
+        description="Topics to exclude from results (e.g. ['machine-learning', 'pytorch'])",
+    )
 
 
 class CompareInput(BaseModel):

--- a/src/opencollab_mcp/tools/discovery.py
+++ b/src/opencollab_mcp/tools/discovery.py
@@ -53,6 +53,8 @@ def register(mcp: FastMCP) -> None:
 
         # TODO: exclude_topics not applied here — issue payloads don't include topics.
         # Would require an extra repo lookup per issue (rate-limit concern). Deferred to follow-up PR.
+        if params.exclude_topics:
+            return json.dumps({"warning": "exclude_topics is not yet supported for this tool — issue payloads don't include topics. Use trending_repos or find_mentor_repos for topic filtering."})
 
         issues = []
         for item in result.get("items", []):
@@ -104,7 +106,7 @@ def register(mcp: FastMCP) -> None:
         except Exception as e:
             return handle_github_error(e)
 
-        normalized_exclude = [t.lower().strip() for t in (params.exclude_topics or [])]
+        normalized_exclude = {t.lower().strip() for t in (params.exclude_topics or [])}
         repos = []
         for r in result.get("items", []):
             topics = r.get("topics", []) or []
@@ -212,7 +214,7 @@ def register(mcp: FastMCP) -> None:
             f"language:{params.language} topic:gsoc good-first-issues:>1 pushed:>{since}",
             f"language:{params.language} topic:mentorship good-first-issues:>1 pushed:>{since}",
         ]
-        normalized_exclude = [t.lower().strip() for t in (params.exclude_topics or [])]
+        normalized_exclude = {t.lower().strip() for t in (params.exclude_topics or [])}
         mentor_topic_signals = {
             "hacktoberfest",
             "gsoc",

--- a/src/opencollab_mcp/tools/discovery.py
+++ b/src/opencollab_mcp/tools/discovery.py
@@ -51,6 +51,9 @@ def register(mcp: FastMCP) -> None:
         except Exception as e:
             return handle_github_error(e)
 
+        # TODO: exclude_topics not applied here — issue payloads don't include topics.
+        # Would require an extra repo lookup per issue (rate-limit concern). Deferred to follow-up PR.
+
         issues = []
         for item in result.get("items", []):
             repo_url = item.get("repository_url", "")
@@ -116,6 +119,14 @@ def register(mcp: FastMCP) -> None:
             }
             for r in result.get("items", [])
         ]
+
+        normalized_exclude = [t.lower().strip() for t in (params.exclude_topics or [])]
+        if normalized_exclude:
+            repos = [
+                r for r in repos
+                if not any(topic in normalized_exclude for topic in r.get("topics", []))
+            ]
+
         return json.dumps({
             "total_found": result.get("total_count", 0),
             "repos": repos,
@@ -238,6 +249,14 @@ def register(mcp: FastMCP) -> None:
                     "last_push_days_ago": days_ago(r.get("pushed_at")),
                 })
         repos.sort(key=lambda x: len(x.get("mentor_signals", [])), reverse=True)
+
+        normalized_exclude = [t.lower().strip() for t in (params.exclude_topics or [])]
+        if normalized_exclude:
+            repos = [
+                r for r in repos
+                if not any(topic in normalized_exclude for topic in r.get("topics", []))
+            ]
+
         return json.dumps({
             "language": params.language,
             "mentor_repos": repos[:15],
@@ -272,6 +291,9 @@ def register(mcp: FastMCP) -> None:
             *(_search_label(label) for label in QUICK_WEEKEND_LABELS[:5]),
             return_exceptions=True,
         )
+
+        # TODO: exclude_topics not applied here — issue payloads don't include topics.
+        # Would require an extra repo lookup per issue (rate-limit concern). Deferred to follow-up PR.
 
         all_issues: list[dict] = []
         seen_urls: set[str] = set()

--- a/src/opencollab_mcp/tools/discovery.py
+++ b/src/opencollab_mcp/tools/discovery.py
@@ -104,28 +104,25 @@ def register(mcp: FastMCP) -> None:
         except Exception as e:
             return handle_github_error(e)
 
-        repos = [
-            {
+        normalized_exclude = [t.lower().strip() for t in (params.exclude_topics or [])]
+        repos = []
+        for r in result.get("items", []):
+            topics = r.get("topics", []) or []
+            if normalized_exclude:
+                if any(topic.lower().strip() in normalized_exclude for topic in topics):
+                    continue
+            repos.append({
                 "name": r.get("full_name", ""),
                 "description": truncate(r.get("description"), 150),
                 "stars": r.get("stargazers_count", 0),
                 "forks": r.get("forks_count", 0),
                 "language": r.get("language"),
                 "open_issues": r.get("open_issues_count", 0),
-                "topics": r.get("topics", [])[:8],
+                "topics": topics[:8],
                 "url": r.get("html_url", ""),
                 "created_days_ago": days_ago(r.get("created_at")),
                 "last_push_days_ago": days_ago(r.get("pushed_at")),
-            }
-            for r in result.get("items", [])
-        ]
-
-        normalized_exclude = [t.lower().strip() for t in (params.exclude_topics or [])]
-        if normalized_exclude:
-            repos = [
-                r for r in repos
-                if not any(topic in normalized_exclude for topic in r.get("topics", []))
-            ]
+            })
 
         return json.dumps({
             "total_found": result.get("total_count", 0),
@@ -215,6 +212,16 @@ def register(mcp: FastMCP) -> None:
             f"language:{params.language} topic:gsoc good-first-issues:>1 pushed:>{since}",
             f"language:{params.language} topic:mentorship good-first-issues:>1 pushed:>{since}",
         ]
+        normalized_exclude = [t.lower().strip() for t in (params.exclude_topics or [])]
+        mentor_topic_signals = {
+            "hacktoberfest",
+            "gsoc",
+            "outreachy",
+            "mentorship",
+            "good-first-issue",
+            "beginner-friendly",
+            "first-timers-only",
+        }
         seen: set[str] = set()
         repos: list[dict] = []
         # Run all three searches in parallel — they're independent.
@@ -231,11 +238,13 @@ def register(mcp: FastMCP) -> None:
                 if name in seen:
                     continue
                 seen.add(name)
-                topics = r.get("topics", [])
+                topics = r.get("topics", []) or []
+                if normalized_exclude:
+                    if any(topic.lower().strip() in normalized_exclude for topic in topics):
+                        continue
                 mentor_signals = [
                     t for t in topics
-                    if t in ("hacktoberfest", "gsoc", "outreachy", "mentorship",
-                             "good-first-issue", "beginner-friendly", "first-timers-only")
+                    if t.lower().strip() in mentor_topic_signals
                 ]
                 repos.append({
                     "name": name,
@@ -249,13 +258,6 @@ def register(mcp: FastMCP) -> None:
                     "last_push_days_ago": days_ago(r.get("pushed_at")),
                 })
         repos.sort(key=lambda x: len(x.get("mentor_signals", [])), reverse=True)
-
-        normalized_exclude = [t.lower().strip() for t in (params.exclude_topics or [])]
-        if normalized_exclude:
-            repos = [
-                r for r in repos
-                if not any(topic in normalized_exclude for topic in r.get("topics", []))
-            ]
 
         return json.dumps({
             "language": params.language,

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -184,3 +184,43 @@ async def test_trending_repos_no_exclusion(mock_github):
     )
     parsed = json.loads(_extract_text(result))
     assert len(parsed["repos"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_find_mentor_repos_excludes_topics(mock_github):
+    mock_github({
+        "/search/repositories": {
+            "items": [
+                {
+                    "full_name": "ml-mentors",
+                    "topics": [
+                        "python",
+                        "fastapi",
+                        "api",
+                        "backend",
+                        "docs",
+                        "tools",
+                        "cli",
+                        "server",
+                        "Machine-Learning",
+                    ],
+                    "description": "",
+                },
+                {
+                    "full_name": "oss-mentors",
+                    "topics": ["mentorship", "python"],
+                    "description": "",
+                },
+            ]
+        }
+    })
+    server = build_server()
+    result = await _call_tool_compat(
+        server,
+        "opencollab_find_mentor_repos",
+        {"params": {"language": "Python", "exclude_topics": ["machine-learning"]}},
+    )
+    parsed = json.loads(_extract_text(result))
+    repo_names = [r["name"] for r in parsed["mentor_repos"]]
+    assert "ml-mentors" not in repo_names
+    assert "oss-mentors" in repo_names

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -142,3 +142,45 @@ async def test_check_issue_availability_invalid_number(mock_github):
     parsed = json.loads(_extract_text(result))
     assert "error" in parsed
     assert "Invalid issue_number" in parsed["error"]
+
+
+@pytest.mark.asyncio
+async def test_trending_repos_excludes_topics(mock_github):
+    mock_github({
+        "/search/repositories": {
+            "items": [
+                {"full_name": "ml-repo", "topics": ["machine-learning", "python"], "description": ""},
+                {"full_name": "web-repo", "topics": ["fastapi", "python"], "description": ""}
+            ]
+        }
+    })
+    server = build_server()
+    result = await _call_tool_compat(
+        server,
+        "opencollab_trending_repos",
+        {"params": {"language": "Python", "exclude_topics": ["machine-learning"]}},
+    )
+    parsed = json.loads(_extract_text(result))
+    repo_names = [r["name"] for r in parsed["repos"]]
+    assert "ml-repo" not in repo_names
+    assert "web-repo" in repo_names
+
+
+@pytest.mark.asyncio
+async def test_trending_repos_no_exclusion(mock_github):
+    mock_github({
+        "/search/repositories": {
+            "items": [
+                {"full_name": "ml-repo", "topics": ["machine-learning"], "description": ""},
+                {"full_name": "web-repo", "topics": ["fastapi"], "description": ""}
+            ]
+        }
+    })
+    server = build_server()
+    result = await _call_tool_compat(
+        server,
+        "opencollab_trending_repos",
+        {"params": {"language": "Python", "exclude_topics": None}},
+    )
+    parsed = json.loads(_extract_text(result))
+    assert len(parsed["repos"]) == 2


### PR DESCRIPTION
Hey @prakhar1605, here's the implementation for the exclude_topics feature.

What I did:
- Added exclude_topics field to LanguageInput in models.py
- Filtered repos in trending_repos and find_mentor_repos using a list comprehension with lowercase normalization
- Left TODO comments in find_issues and weekend_issues since issue payloads don't have topics (as you suggested)
- Added two test cases in test_tools.py

All 47 tests passing, ruff clean.

Closes #1 