### PR TITLE
Quote the language and exclude pull requests in both search queries

### DIFF
--- a/src/opencollab_mcp/tools/discovery.py
+++ b/src/opencollab_mcp/tools/discovery.py
@@ -32,9 +32,15 @@ def register(mcp: FastMCP) -> None:
         since = recent_date_str(RECENT_ISSUES_DAYS)
         label = 'label:"good first issue"' if params.difficulty == "beginner" else 'label:"help wanted"'
         query_parts = [
-            f"language:{params.language}",
+            # The language is quoted so multi-word values survive: bare
+            # `language:Jupyter Notebook` is parsed by GitHub as
+            # `language:Jupyter` plus a free-text `Notebook`.
+            f'language:"{params.language}"',
             label,
             "state:open",
+            # /search/issues returns pull requests too, and a PR carrying the
+            # label would otherwise look like an issue to pick up.
+            "is:issue",
             f"created:>{since}",
             "is:public",
         ]
@@ -113,8 +119,8 @@ def register(mcp: FastMCP) -> None:
         try:
             result = await github_search(
                 "issues",
-                f'language:{primary_lang} label:"good first issue" state:open '
-                f'created:>{since} is:public',
+                f'language:"{primary_lang}" label:"good first issue" state:open '
+                f'is:issue created:>{since} is:public',
                 {"sort": "created", "order": "desc", "per_page": 10},
             )
         except Exception as e:

--- a/tests/test_discovery_queries.py
+++ b/tests/test_discovery_queries.py
@@ -1,0 +1,141 @@
+"""Tests for the GitHub search queries the discovery tools build.
+
+The queries are the whole product of these tools: a wrong qualifier does not
+raise, it just returns the wrong issues. These tests capture the query string
+handed to github_search and assert on it directly.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from opencollab_mcp.server import build_server
+from opencollab_mcp.tools import discovery
+
+
+@pytest.fixture
+def captured_queries(monkeypatch) -> list[str]:
+    """Record every query string the discovery tools send to GitHub."""
+    queries: list[str] = []
+
+    async def _fake_search(endpoint: str, query: str, params: dict[str, Any] | None = None):
+        queries.append(query)
+        return {"total_count": 0, "items": []}
+
+    monkeypatch.setattr(discovery, "github_search", _fake_search)
+    return queries
+
+
+async def _call(server, name: str, arguments: dict):
+    result = server.call_tool(name, arguments)
+    if hasattr(result, "__await__"):
+        result = await result
+    return result
+
+
+@pytest.fixture
+def server():
+    return build_server()
+
+
+# ---- language quoting (#13) ------------------------------------------------
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "language",
+    ["Jupyter Notebook", "Vim Script", "Common Lisp", "Emacs Lisp"],
+)
+async def test_find_issues_quotes_multi_word_language(server, captured_queries, language):
+    await _call(server, "opencollab_find_issues", {"params": {"language": language}})
+
+    assert captured_queries, "the tool did not reach github_search"
+    assert f'language:"{language}"' in captured_queries[0]
+
+
+@pytest.mark.asyncio
+async def test_find_issues_quotes_single_word_language(server, captured_queries):
+    await _call(server, "opencollab_find_issues", {"params": {"language": "Python"}})
+
+    assert 'language:"Python"' in captured_queries[0]
+
+
+@pytest.mark.asyncio
+async def test_match_me_quotes_detected_language(server, captured_queries, mock_github):
+    mock_github({
+        "/users/dataperson": {"login": "dataperson", "name": "Data Person"},
+        "/users/dataperson/repos": [
+            {"language": "Jupyter Notebook", "size": 900, "topics": ["ml"]},
+            {"language": "Python", "size": 100, "topics": []},
+        ],
+    })
+
+    await _call(server, "opencollab_match_me", {"params": {"username": "dataperson"}})
+
+    assert captured_queries, "the tool did not reach github_search"
+    assert 'language:"Jupyter Notebook"' in captured_queries[0]
+
+
+# ---- is:issue (#11) --------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_find_issues_excludes_pull_requests(server, captured_queries):
+    await _call(server, "opencollab_find_issues", {"params": {"language": "Go"}})
+
+    assert "is:issue" in captured_queries[0].split()
+
+
+@pytest.mark.asyncio
+async def test_match_me_excludes_pull_requests(server, captured_queries, mock_github):
+    mock_github({
+        "/users/gopher": {"login": "gopher"},
+        "/users/gopher/repos": [{"language": "Go", "size": 500, "topics": []}],
+    })
+
+    await _call(server, "opencollab_match_me", {"params": {"username": "gopher"}})
+
+    assert "is:issue" in captured_queries[0].split()
+
+
+# ---- the rest of the query is unchanged ------------------------------------
+
+@pytest.mark.asyncio
+async def test_find_issues_keeps_its_other_qualifiers(server, captured_queries):
+    await _call(server, "opencollab_find_issues", {"params": {"language": "Rust"}})
+
+    query = captured_queries[0]
+    assert 'label:"good first issue"' in query
+    assert "state:open" in query.split()
+    assert "is:public" in query.split()
+    assert "created:>" in query
+
+
+@pytest.mark.asyncio
+async def test_find_issues_intermediate_keeps_quoting_and_is_issue(server, captured_queries):
+    await _call(
+        server,
+        "opencollab_find_issues",
+        {"params": {"language": "Jupyter Notebook", "difficulty": "intermediate"}},
+    )
+
+    query = captured_queries[0]
+    assert 'language:"Jupyter Notebook"' in query
+    assert 'label:"help wanted"' in query
+    assert "is:issue" in query.split()
+
+
+@pytest.mark.asyncio
+async def test_match_me_keeps_its_other_qualifiers(server, captured_queries, mock_github):
+    mock_github({
+        "/users/rustacean": {"login": "rustacean"},
+        "/users/rustacean/repos": [{"language": "Rust", "size": 500, "topics": []}],
+    })
+
+    await _call(server, "opencollab_match_me", {"params": {"username": "rustacean"}})
+
+    query = captured_queries[0]
+    assert 'label:"good first issue"' in query
+    assert "state:open" in query.split()
+    assert "is:public" in query.split()
+    assert "created:>" in query


### PR DESCRIPTION
Closes #13, closes #11.

Two wrong-results bugs that live on **the same two lines** — the `query_parts` list in `opencollab_find_issues` and the inline query in `opencollab_match_me`. Fixed together rather than as two PRs that would conflict with each other; happy to split if you'd rather.

## #13 — multi-word languages

`f"language:{params.language}"` interpolated the value bare, so `Jupyter Notebook` produced:

```
language:Jupyter Notebook ...
```

GitHub reads that as `language:Jupyter` plus a free-text term `Notebook`. Quoting fixes it, and single-word languages are unaffected:

```
language:"Jupyter Notebook" ...
```

This hits `opencollab_match_me` hardest, exactly as the issue says: it *auto-detects* the language, and `Jupyter Notebook` is precisely what it detects for a data-science profile.

## #11 — pull requests in the results

Neither query carried `is:issue`, and `/search/issues` returns pull requests too. A PR carrying the `good first issue` label was presented as an issue someone could pick up. Both queries now include it.

## Tests

New `tests/test_discovery_queries.py`. The queries are the whole product of these tools — a wrong qualifier does not raise, it quietly returns the wrong issues — so the tests capture the query string handed to `github_search` (by monkeypatching it in the `discovery` module namespace) and assert on it directly:

- `language:"..."` for `Jupyter Notebook`, `Vim Script`, `Common Lisp`, `Emacs Lisp`, and for a single-word `Python`;
- `match_me` quotes the language it *detected* — driven through the existing `mock_github` fixture with a profile whose largest repo is `Jupyter Notebook`;
- `is:issue` present in both queries;
- and two tests asserting the rest of each query is untouched (`label:"good first issue"`, `state:open`, `is:public`, `created:>`), so a future edit cannot drop a qualifier while the new assertions still pass.

8 of the 10 fail on `main`.

## Verification

```
pytest      # 56 passed
ruff check .  # All checks passed
```

## Unrelated, but you may want to know

`pip install -e ".[dev]"` on a clean environment currently installs `mcp` 2.0.0 (the pin is `mcp[cli]>=1.2.0` with no upper bound), and 2.0.0 has no `mcp.server.fastmcp` — every test errors on import. I worked against `mcp[cli]<2` (1.29.0). Worth a separate issue; I did not touch the pin here since it is outside these two.