### PR TITLE
Derive the version from package metadata instead of copying it

### DIFF
--- a/src/opencollab_mcp/__init__.py
+++ b/src/opencollab_mcp/__init__.py
@@ -1,7 +1,6 @@
 """OpenCollab MCP — AI-powered open source contribution matchmaker."""
 
-__version__ = "0.6.1"
-
+from .constants import __version__
 from .server import build_server, main, mcp
 
 __all__ = ["build_server", "main", "mcp", "__version__"]

--- a/src/opencollab_mcp/constants.py
+++ b/src/opencollab_mcp/constants.py
@@ -4,10 +4,22 @@ Pulling these out of individual tools keeps scoring logic self-documenting
 and makes tuning a one-line change instead of a hunt-and-peck across files.
 """
 
+from importlib.metadata import PackageNotFoundError, version
+
+# ---- Version ----
+# pyproject.toml is the single source of truth; everything else reads it back
+# out of the installed distribution metadata. A hard-coded copy here is how the
+# User-Agent came to advertise 0.6.0 while the package was 0.6.1.
+try:
+    __version__ = version("opencollab-mcp")
+except PackageNotFoundError:
+    # Running from a source tree that was never installed.
+    __version__ = "0.0.0-dev"
+
 # ---- API / network ----
 GITHUB_API_BASE = "https://api.github.com"
 DEFAULT_TIMEOUT = 30.0
-USER_AGENT = "opencollab-mcp/0.6.0"
+USER_AGENT = f"opencollab-mcp/{__version__}"
 GITHUB_API_VERSION = "2022-11-28"
 
 # ---- Caching ----

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,65 @@
+"""The package version has one home: pyproject.toml.
+
+These tests exist because it previously had three, and they had already
+drifted — every request advertised opencollab-mcp/0.6.0 while the package was
+0.6.1, and nothing failed.
+"""
+
+from __future__ import annotations
+
+from importlib.metadata import version
+from pathlib import Path
+
+import httpx
+import pytest
+
+import opencollab_mcp
+from opencollab_mcp import constants, github_client
+
+SRC = Path(opencollab_mcp.__file__).resolve().parent
+
+
+def test_dunder_version_matches_distribution_metadata():
+    assert opencollab_mcp.__version__ == version("opencollab-mcp")
+
+
+def test_user_agent_is_derived_from_the_version():
+    assert constants.USER_AGENT == f"opencollab-mcp/{opencollab_mcp.__version__}"
+
+
+def test_no_hardcoded_version_literal_in_the_package():
+    # The regression this guards: a second copy of the number, free to drift
+    # from pyproject.toml the way USER_AGENT did.
+    current = version("opencollab-mcp")
+    offenders = [
+        f"{path.relative_to(SRC)}:{lineno}: {line.strip()}"
+        for path in SRC.rglob("*.py")
+        for lineno, line in enumerate(path.read_text().splitlines(), start=1)
+        if current in line and not line.lstrip().startswith("#")
+    ]
+
+    assert not offenders, (
+        f"the version {current!r} is written down inside the package; "
+        "pyproject.toml is the only place it belongs:\n" + "\n".join(offenders)
+    )
+
+
+@pytest.mark.asyncio
+async def test_requests_advertise_the_current_version(monkeypatch):
+    seen: list[str] = []
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request.headers["User-Agent"])
+        return httpx.Response(200, json={})
+
+    transport = httpx.MockTransport(_handler)
+    real_async_client = httpx.AsyncClient
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        lambda *a, **kw: real_async_client(*a, **{**kw, "transport": transport}),
+    )
+
+    await github_client.github_get("/rate_limit", use_cache=False)
+
+    assert seen == [f"opencollab-mcp/{version('opencollab-mcp')}"]


### PR DESCRIPTION
Closes #10.

## Problem

The version lived in three places and had already drifted:

| File | Value |
|---|---|
| `pyproject.toml` | `0.6.1` |
| `__init__.py` → `__version__` | `0.6.1` |
| `constants.py` → `USER_AGENT` | `opencollab-mcp/0.6.0` ← stale |

Every request to GitHub advertised the wrong version, and nothing failed.

## Fix

`pyproject.toml` is now the only place the number appears. `constants.py` resolves it from the installed distribution metadata and builds the User-Agent from it:

```python
try:
    __version__ = version("opencollab-mcp")
except PackageNotFoundError:
    __version__ = "0.0.0-dev"

USER_AGENT = f"opencollab-mcp/{__version__}"
```

`__init__.py` re-exports it rather than holding a second copy. It is resolved in `constants.py` rather than `__init__.py` because `__init__` imports `.server`, so resolving it there and reading it back from `constants` would be an import cycle.

```
>>> opencollab_mcp.__version__
'0.6.1'
>>> constants.USER_AGENT
'opencollab-mcp/0.6.1'
```

## Tests

New `tests/test_version.py`, four tests pinning the properties that were actually violated:

- `__version__` equals the distribution metadata;
- `USER_AGENT` is derived from `__version__`;
- **the version string does not appear as a literal anywhere under `src/`** — this is the one that would have caught the original drift. Checked by mutation: putting `USER_AGENT = "opencollab-mcp/0.6.1"` back fails it;
- a real request through `github_get` (with a `MockTransport`) carries `opencollab-mcp/<current version>` in its `User-Agent` header — the end the bug was actually visible from.

I deliberately did **not** add a test that parses `pyproject.toml` directly: `tomllib` is stdlib only from 3.11 and this package supports 3.10. The metadata check covers the same property on every supported version.

## Verification

```
pytest        # 50 passed
ruff check .  # All checks passed
```

## Note

On a clean environment `pip install -e ".[dev]"` currently pulls `mcp` 2.0.0 (the pin is `mcp[cli]>=1.2.0`, no upper bound), which has no `mcp.server.fastmcp` and errors on import before any test runs. I verified against `mcp[cli]<2` (1.29.0). Unrelated to this change, but probably worth its own issue.