### PR TITLE
Reuse one httpx.AsyncClient instead of one per request

### DIFF
--- a/src/opencollab_mcp/github_client.py
+++ b/src/opencollab_mcp/github_client.py
@@ -66,6 +66,33 @@ def clear_cache() -> None:
 
 # ---- HTTP -----------------------------------------------------------------
 
+# One client, one connection pool. Tools like repo_health and
+# generate_pr_plan fan out 3-5 requests through asyncio.gather, and a
+# per-request client paid a fresh TCP + TLS handshake for every one of them.
+_client: httpx.AsyncClient | None = None
+
+
+def _get_client() -> httpx.AsyncClient:
+    """Return the shared client, creating it on first use."""
+    global _client
+    if _client is None or _client.is_closed:
+        _client = httpx.AsyncClient(timeout=DEFAULT_TIMEOUT)
+    return _client
+
+
+def reset_client() -> None:
+    """Drop the shared client so the next request builds a fresh one.
+
+    Useful for tests, in the same way as clear_cache(): a test that installs a
+    mock transport by patching httpx.AsyncClient needs the next request to go
+    through the patch rather than reuse a client built earlier. The old client
+    is not awaited closed — it holds only idle pooled connections, and this is
+    not a production code path.
+    """
+    global _client
+    _client = None
+
+
 def _get_headers() -> dict[str, str]:
     """Build auth headers from environment."""
     token = os.environ.get("GITHUB_TOKEN", "")
@@ -96,25 +123,24 @@ async def github_get(
         if cached is not None:
             return cached
 
-    async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT) as client:
-        resp = await client.get(
-            f"{GITHUB_API_BASE}{path}",
-            headers=_get_headers(),
-            params=params or {},
-        )
+    resp = await _get_client().get(
+        f"{GITHUB_API_BASE}{path}",
+        headers=_get_headers(),
+        params=params or {},
+    )
 
-        # GitHub returns 202 with empty body while it computes statistics
-        # (commit_activity, participation, contributors on cold repos).
-        if resp.status_code == 202:
-            logger.info("GitHub returned 202 (stats computing) for %s", path)
-            return {}
+    # GitHub returns 202 with empty body while it computes statistics
+    # (commit_activity, participation, contributors on cold repos).
+    if resp.status_code == 202:
+        logger.info("GitHub returned 202 (stats computing) for %s", path)
+        return {}
 
-        resp.raise_for_status()
-        try:
-            data = resp.json()
-        except ValueError:
-            logger.warning("Non-JSON response from %s", path)
-            return {}
+    resp.raise_for_status()
+    try:
+        data = resp.json()
+    except ValueError:
+        logger.warning("Non-JSON response from %s", path)
+        return {}
 
     if use_cache:
         _cache_set(key, data)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,11 +12,18 @@ from opencollab_mcp import github_client
 
 
 @pytest.fixture(autouse=True)
-def _clear_cache():
-    """Every test gets a clean cache — prevents leakage across tests."""
+def _reset_client_state():
+    """Every test gets a clean cache and a fresh HTTP client.
+
+    Resetting the client matters as much as the cache: it is shared and
+    lazily created, so without this a test could reuse a client built by an
+    earlier test — one that was not built through this test's mock transport.
+    """
     github_client.clear_cache()
+    github_client.reset_client()
     yield
     github_client.clear_cache()
+    github_client.reset_client()
 
 
 @pytest.fixture

--- a/tests/test_github_client.py
+++ b/tests/test_github_client.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+
 import httpx
 import pytest
 
@@ -91,3 +93,93 @@ def test_handle_github_error_timeout():
 def test_handle_github_error_unknown():
     msg = github_client.handle_github_error(RuntimeError("boom"))
     assert "RuntimeError" in msg
+
+
+@pytest.mark.asyncio
+async def test_github_get_reuses_one_client(monkeypatch):
+    """One AsyncClient, one connection pool — not a handshake per request."""
+    constructions = {"n": 0}
+    built: list[httpx.AsyncClient] = []
+
+    transport = httpx.MockTransport(lambda r: httpx.Response(200, json={"ok": True}))
+    real_async_client = httpx.AsyncClient
+
+    def _counting(*args, **kwargs):
+        constructions["n"] += 1
+        kwargs["transport"] = transport
+        client = real_async_client(*args, **kwargs)
+        built.append(client)
+        return client
+
+    monkeypatch.setattr(httpx, "AsyncClient", _counting)
+
+    # Distinct paths, so the cache cannot hide a second construction.
+    await github_client.github_get("/users/one")
+    await github_client.github_get("/users/two")
+    await github_client.github_get("/users/three")
+
+    assert constructions["n"] == 1, "a client was built per request"
+    assert built[0] is github_client._get_client()
+
+
+@pytest.mark.asyncio
+async def test_client_survives_between_requests(monkeypatch):
+    """The shared client must still be open after a request completes.
+
+    The previous implementation used `async with`, which closed the client at
+    the end of every call; reusing that object would raise.
+    """
+    transport = httpx.MockTransport(lambda r: httpx.Response(200, json={}))
+    real_async_client = httpx.AsyncClient
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        lambda *a, **kw: real_async_client(*a, **{**kw, "transport": transport}),
+    )
+
+    await github_client.github_get("/users/first", use_cache=False)
+    client = github_client._get_client()
+
+    assert not client.is_closed
+    await github_client.github_get("/users/second", use_cache=False)
+    assert github_client._get_client() is client
+
+
+@pytest.mark.asyncio
+async def test_concurrent_requests_share_the_client(monkeypatch):
+    """The fan-out case from the issue: gather must not build N clients."""
+    constructions = {"n": 0}
+    transport = httpx.MockTransport(lambda r: httpx.Response(200, json={}))
+    real_async_client = httpx.AsyncClient
+
+    def _counting(*args, **kwargs):
+        constructions["n"] += 1
+        kwargs["transport"] = transport
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", _counting)
+
+    await asyncio.gather(*(
+        github_client.github_get(f"/repos/o/r/{n}") for n in ("a", "b", "c", "d", "e")
+    ))
+
+    assert constructions["n"] == 1
+
+
+def test_reset_client_forces_a_new_one(monkeypatch):
+    """reset_client is the seam tests need after patching httpx.AsyncClient."""
+    first = github_client._get_client()
+    assert github_client._get_client() is first
+
+    github_client.reset_client()
+
+    assert github_client._get_client() is not first
+
+
+@pytest.mark.asyncio
+async def test_closed_client_is_replaced(monkeypatch):
+    """A client closed out from under us is rebuilt rather than reused."""
+    client = github_client._get_client()
+    await client.aclose()
+
+    assert github_client._get_client() is not client


### PR DESCRIPTION
Closes #15.

## Problem

`github_get` opened a brand-new `AsyncClient` inside an `async with` for every call, then closed it again immediately:

```python
async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT) as client:
    resp = await client.get(...)
```

A fresh TCP + TLS handshake per request. `opencollab_repo_health` and `opencollab_generate_pr_plan` fan out 3–5 requests through `asyncio.gather`, so the handshake tax was paid repeatedly inside a single tool call.

## Fix

A module-level client, created lazily and reused, rebuilt if it has been closed:

```python
def _get_client() -> httpx.AsyncClient:
    global _client
    if _client is None or _client.is_closed:
        _client = httpx.AsyncClient(timeout=DEFAULT_TIMEOUT)
    return _client
```

## Keeping the tests injectable

This is the part the issue warned about. The tests install a mock transport by patching `httpx.AsyncClient`, and a shared client built during an *earlier* test would not go through that patch — a test could silently reach the real network depending on ordering.

So `reset_client()` is added next to `clear_cache()`, and the existing autouse fixture in `conftest.py` calls both. Every test still gets a client bound to its own transport, and **no existing test needed changing**.

`reset_client()` drops the reference without awaiting `aclose()`, and says so in its docstring: the client holds only idle pooled connections, and this is a test seam, not a production path.

## Tests

Five new tests in `tests/test_github_client.py`:

- `test_github_get_reuses_one_client` — three requests to **distinct** paths (so the cache cannot hide a second construction) build exactly one client, and it is the one `_get_client()` returns. This is the acceptance criterion, checked both ways the issue suggests: construction count *and* object identity.
- `test_client_survives_between_requests` — the client is still open after a request finishes. Under the old `async with` it was closed at the end of every call, so reusing it would raise.
- `test_concurrent_requests_share_the_client` — the fan-out case: `asyncio.gather` over five requests builds one client.
- `test_reset_client_forces_a_new_one` — the seam itself.
- `test_closed_client_is_replaced` — a client closed out from under us is rebuilt, not reused.

The first three fail on `main`.

## Verification

```
pytest        # 51 passed
ruff check .  # All checks passed
```