### PR TITLE
Say so when match_me falls back to Python

### DIFF
--- a/src/opencollab_mcp/tools/discovery.py
+++ b/src/opencollab_mcp/tools/discovery.py
@@ -106,7 +106,11 @@ def register(mcp: FastMCP) -> None:
             {"name": n, "percentage": round(b / total * 100, 1)}
             for n, b in top_langs
         ]
-        primary_lang = top_langs[0][0] if top_langs else "Python"
+        # A profile with no owned repo carrying language data — a brand-new
+        # account, a fork-only account, an org-only contributor — would
+        # otherwise be served Python issues as though Python had been detected.
+        language_detected = bool(top_langs)
+        primary_lang = top_langs[0][0] if language_detected else "Python"
         since = recent_date_str(RECENT_ISSUES_DAYS)
         try:
             result = await github_search(
@@ -129,11 +133,23 @@ def register(mcp: FastMCP) -> None:
             }
             for it in result.get("items", [])
         ]
-        return json.dumps({
+        payload: dict[str, object] = {
             "username": params.username,
             "name": user.get("name"),
             "top_languages": languages,
             "topics": sorted(topics_set)[:10],
             "matched_language": primary_lang,
             "matched_issues": issues,
-        }, indent=2)
+        }
+        if not language_detected:
+            # Present only when the fallback fired, so its presence is the
+            # signal — an assistant reading the response cannot miss it the way
+            # it can miss a null.
+            payload["language_fallback"] = True
+            payload["note"] = (
+                "No language data was found on this profile, so the search "
+                "defaulted to Python. These matches are not based on the "
+                "user's actual skills. Ask the user which language they want "
+                "and call opencollab_find_issues with it."
+            )
+        return json.dumps(payload, indent=2)

--- a/tests/test_match_me_fallback.py
+++ b/tests/test_match_me_fallback.py
@@ -1,0 +1,92 @@
+"""match_me must not present a guess as a detection.
+
+With no language data on a profile the tool falls back to Python. That is a
+reasonable default, but the assistant relaying the results has no way to know
+it happened unless the response says so.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from opencollab_mcp.server import build_server
+from opencollab_mcp.tools import discovery
+
+
+@pytest.fixture
+def no_search(monkeypatch):
+    """Stub the issue search: these tests are about the response envelope."""
+
+    async def _fake_search(endpoint: str, query: str, params: dict[str, Any] | None = None):
+        return {"total_count": 0, "items": []}
+
+    monkeypatch.setattr(discovery, "github_search", _fake_search)
+
+
+@pytest.fixture
+def server():
+    return build_server()
+
+
+async def _match_me(server, username: str) -> dict[str, Any]:
+    result = server.call_tool("opencollab_match_me", {"params": {"username": username}})
+    if hasattr(result, "__await__"):
+        result = await result
+    text = result[0][0].text if isinstance(result, tuple) else result[0].text
+    return json.loads(text)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("label", "repos"),
+    [
+        ("brand-new account", []),
+        ("fork-only account", [{"language": None, "size": 10, "topics": []}]),
+        ("repos with no language", [{"size": 10, "topics": ["docs"]}]),
+    ],
+)
+async def test_match_me_flags_the_python_fallback(server, no_search, mock_github, label, repos):
+    mock_github({"/users/nobody": {"login": "nobody"}, "/users/nobody/repos": repos})
+
+    payload = await _match_me(server, "nobody")
+
+    assert payload["matched_language"] == "Python", label
+    assert payload["language_fallback"] is True, label
+    assert "note" in payload, f"{label}: the fallback is invisible to the assistant"
+    assert "defaulted to Python" in payload["note"]
+    assert "opencollab_find_issues" in payload["note"], "the note should say what to do next"
+
+
+@pytest.mark.asyncio
+async def test_match_me_says_nothing_when_a_language_is_detected(server, no_search, mock_github):
+    mock_github({
+        "/users/gopher": {"login": "gopher"},
+        "/users/gopher/repos": [{"language": "Go", "size": 500, "topics": []}],
+    })
+
+    payload = await _match_me(server, "gopher")
+
+    assert payload["matched_language"] == "Go"
+    assert "language_fallback" not in payload, "the flag must not appear on the happy path"
+    assert "note" not in payload, "no null key on the happy path"
+
+
+@pytest.mark.asyncio
+async def test_match_me_response_shape_is_otherwise_unchanged(server, no_search, mock_github):
+    mock_github({
+        "/users/gopher": {"login": "gopher", "name": "Go Pher"},
+        "/users/gopher/repos": [{"language": "Go", "size": 500, "topics": ["cli"]}],
+    })
+
+    payload = await _match_me(server, "gopher")
+
+    assert set(payload) == {
+        "username", "name", "top_languages", "topics",
+        "matched_language", "matched_issues",
+    }
+    assert payload["name"] == "Go Pher"
+    assert payload["topics"] == ["cli"]
+    assert payload["top_languages"] == [{"name": "Go", "percentage": 100.0}]


### PR DESCRIPTION
Closes #17.

## Problem

```python
primary_lang = top_langs[0][0] if top_langs else "Python"
```

With no owned repo carrying language data — a brand-new account, a fork-only account, an org-only contributor — `opencollab_match_me` quietly picked Python and returned Python issues. The assistant relayed them with full confidence, and the user had no way to know the recommendation rested on nothing.

## Fix

The fallback stays. It is now visible in the response:

```json
{
  "matched_language": "Python",
  "language_fallback": true,
  "note": "No language data was found on this profile, so the search defaulted to Python. These matches are not based on the user's actual skills. Ask the user which language they want and call opencollab_find_issues with it."
}
```

Two details worth a moment:

- **The keys are absent, not null, when a language was detected** — the option the issue offered. Presence is then the signal, which an assistant reading the JSON cannot miss the way it can skim past `"note": null`.
- The note says **what to do next**, not just what went wrong. This is a tool talking to an assistant, so a next action is more useful than a diagnosis.

## Tests

New `tests/test_match_me_fallback.py`, 5 tests:

- the fallback is flagged for all three profiles the issue names — empty repo list, repos with `language: null`, repos with no language key at all — and the note names both the default and the recommended next call;
- nothing appears on the happy path: neither key is present when a language *was* detected;
- the rest of the response envelope is byte-for-byte what it was — exact key set, `name`, `topics`, `top_languages` percentages — so the change cannot have quietly reshaped anything else.

The first three fail on `main`.

## Verification

```
pytest        # 51 passed
ruff check .  # All checks passed
```