### PR TITLE
Tell a rate-limited 403 apart from a denied one

### DIFF
--- a/src/opencollab_mcp/github_client.py
+++ b/src/opencollab_mcp/github_client.py
@@ -157,6 +157,26 @@ async def github_search(
     return await github_get(f"/search/{endpoint}", merged)
 
 
+def _reset_hint(response: httpx.Response) -> str:
+    """" Resets in ~N minutes." for a usable x-ratelimit-reset, else "".
+
+    The header is a Unix epoch timestamp. A missing, unparseable or already
+    past value yields nothing rather than a nonsense "resets in -3 minutes":
+    a vague message beats a wrong one.
+    """
+    raw = response.headers.get("x-ratelimit-reset", "")
+    try:
+        reset_at = int(raw)
+    except ValueError:
+        return ""
+    seconds = reset_at - time.time()
+    if seconds <= 0:
+        return ""
+    if seconds < 60:
+        return " Resets in under a minute."
+    return f" Resets in ~{round(seconds / 60)} minutes."
+
+
 def handle_github_error(e: Exception) -> str:
     """Return a human-friendly error string for GitHub API failures.
 
@@ -170,11 +190,19 @@ def handle_github_error(e: Exception) -> str:
         if code == 401:
             return ("Error: GitHub authentication failed. "
                     "Check your GITHUB_TOKEN environment variable.")
-        if code == 403:
-            remaining = e.response.headers.get("x-ratelimit-remaining", "?")
-            return (f"Error: GitHub API rate limit or permission issue "
-                    f"(remaining: {remaining}). Try again later or use a "
-                    f"token with more scopes.")
+        if code in (403, 429):
+            # GitHub says which of the two a 403 is: exhausted quota leaves
+            # x-ratelimit-remaining at "0", anything else is a permissions
+            # problem. Reporting them together sent people to check the wrong
+            # thing half the time. 429 is always a limit (secondary limits).
+            remaining = e.response.headers.get("x-ratelimit-remaining", "")
+            if code == 429 or remaining == "0":
+                return (f"Error: GitHub API rate limit exceeded."
+                        f"{_reset_hint(e.response)} Set GITHUB_TOKEN for a "
+                        f"5,000 requests/hour limit.")
+            return ("Error: GitHub denied access (403). Your token may be "
+                    "missing the 'public_repo' scope, or the resource is "
+                    "private.")
         if code == 404:
             return "Error: Resource not found on GitHub. Double-check the username or repo name."
         if code == 422:

--- a/tests/test_github_client.py
+++ b/tests/test_github_client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import time
 
 import httpx
 import pytest
@@ -67,13 +68,73 @@ def test_handle_github_error_401():
     assert "authentication" in msg.lower()
 
 
-def test_handle_github_error_403_includes_remaining():
+def _status_error(code: int, headers: dict[str, str] | None = None) -> httpx.HTTPStatusError:
     request = httpx.Request("GET", "https://api.github.com/test")
-    response = httpx.Response(403, headers={"x-ratelimit-remaining": "0"}, request=request)
-    err = httpx.HTTPStatusError("rate", request=request, response=response)
-    msg = github_client.handle_github_error(err)
+    response = httpx.Response(code, headers=headers or {}, request=request)
+    return httpx.HTTPStatusError("boom", request=request, response=response)
+
+
+def test_handle_github_error_403_exhausted_quota_is_a_rate_limit():
+    msg = github_client.handle_github_error(
+        _status_error(403, {"x-ratelimit-remaining": "0"})
+    )
     assert "rate limit" in msg.lower()
-    assert "remaining: 0" in msg
+    assert "GITHUB_TOKEN" in msg
+    assert "scope" not in msg.lower(), "a quota problem must not send people to check scopes"
+
+
+def test_handle_github_error_403_with_quota_left_is_a_permission_problem():
+    msg = github_client.handle_github_error(
+        _status_error(403, {"x-ratelimit-remaining": "4999"})
+    )
+    assert "denied access" in msg.lower()
+    assert "public_repo" in msg
+    assert "rate limit" not in msg.lower(), "a scope problem must not read as a quota problem"
+
+
+def test_handle_github_error_403_without_the_header_reads_as_permissions():
+    # No header at all: GitHub sends the remaining count on every rate-limited
+    # response, so its absence is not a quota problem.
+    msg = github_client.handle_github_error(_status_error(403))
+    assert "denied access" in msg.lower()
+
+
+def test_handle_github_error_429_is_always_a_rate_limit():
+    # Secondary limits come back as 429 with no remaining header.
+    msg = github_client.handle_github_error(_status_error(429))
+    assert "rate limit" in msg.lower()
+
+
+def test_rate_limit_message_says_when_to_retry():
+    reset = int(time.time()) + 12 * 60
+    msg = github_client.handle_github_error(
+        _status_error(403, {"x-ratelimit-remaining": "0", "x-ratelimit-reset": str(reset)})
+    )
+    assert "rate limit" in msg.lower()
+    assert "12 minutes" in msg
+
+
+def test_rate_limit_message_rounds_a_near_reset_to_under_a_minute():
+    reset = int(time.time()) + 20
+    msg = github_client.handle_github_error(
+        _status_error(403, {"x-ratelimit-remaining": "0", "x-ratelimit-reset": str(reset)})
+    )
+    assert "under a minute" in msg
+
+
+@pytest.mark.parametrize(
+    "reset",
+    ["", "not-a-number", str(int(time.time()) - 300)],
+)
+def test_rate_limit_message_omits_a_reset_it_cannot_trust(reset):
+    # A missing, unparseable or already-past reset must not become
+    # "resets in ~-5 minutes" — vague beats wrong.
+    msg = github_client.handle_github_error(
+        _status_error(403, {"x-ratelimit-remaining": "0", "x-ratelimit-reset": reset})
+    )
+    assert "rate limit" in msg.lower()
+    assert "resets in" not in msg.lower()
+    assert "-" not in msg.split("exceeded.")[1]
 
 
 def test_handle_github_error_404():


### PR DESCRIPTION
Closes #14.

## Problem

Every 403 produced the same line:

```
Error: GitHub API rate limit or permission issue (remaining: ?). Try again later or use a token with more scopes.
```

Two unrelated problems, one message — so half the time it sent the user to check the wrong thing. GitHub already tells us which it is.

## Fix

```
403, x-ratelimit-remaining: 0
  → Error: GitHub API rate limit exceeded. Resets in ~12 minutes. Set GITHUB_TOKEN for a 5,000 requests/hour limit.

403, x-ratelimit-remaining: 4999
  → Error: GitHub denied access (403). Your token may be missing the 'public_repo' scope, or the resource is private.

429 (secondary limit, no remaining header)
  → Error: GitHub API rate limit exceeded. Set GITHUB_TOKEN for a 5,000 requests/hour limit.
```

Three judgement calls beyond the issue text:

- **A 403 with no `x-ratelimit-remaining` reads as permissions.** GitHub sends that header on every rate-limited response, so its absence is evidence against a quota problem.
- **An untrustworthy reset is omitted entirely.** Missing, unparseable, or already in the past yields no time rather than `resets in ~-5 minutes` — a vague message beats a wrong one.
- **Under a minute says "under a minute"** instead of rounding to `~0 minutes`.

## Tests

`test_handle_github_error_403_includes_remaining` asserted on the merged message, so it is replaced by the two split cases, as the issue asked. A small `_status_error` helper replaces the repeated three-line request/response setup.

Both new messages are tested from both directions — the quota case asserts `"scope"` is **absent**, the permissions case asserts `"rate limit"` is absent — so the two cannot quietly converge again. Plus: the missing-header case, 429, the reset wording (12 minutes, and under a minute), and a parametrised test over the three untrustworthy reset values.

## Verification

```
pytest        # 54 passed
ruff check .  # All checks passed
```