### PR TITLE
feat: add difficulty filter to issue discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ The AI picks which tools to call based on what you ask.
 | Tool | What it does |
 |---|---|
 | `opencollab_match_me` | Reads your GitHub profile, detects your top language, returns 10 matching good-first-issues — all in one call. |
-| `opencollab_find_issues` | Up to 15 recent good-first-issues for a given language. |
+| `opencollab_find_issues` | Up to 15 recent issues for a given language, with beginner (`good first issue`) and intermediate (`help wanted`) difficulty filters. |
 
 </details>
 

--- a/src/opencollab_mcp/models.py
+++ b/src/opencollab_mcp/models.py
@@ -6,6 +6,8 @@ LLM-generated tool calls passing through stray keys.
 
 from __future__ import annotations
 
+from typing import Literal
+
 from pydantic import BaseModel, ConfigDict, Field
 
 
@@ -32,11 +34,16 @@ class IssueInput(BaseModel):
         min_length=1,
     )
 
-
 class LanguageInput(BaseModel):
     model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
+
     language: str = Field(
         ...,
         description="Programming language (e.g. 'Python', 'TypeScript', 'Rust')",
         min_length=1,
     )
+
+    difficulty: Literal["beginner", "intermediate"] = Field(
+        default="beginner",
+        description='beginner searches label:"good first issue"; intermediate searches label:"help wanted"',
+)

--- a/src/opencollab_mcp/tools/discovery.py
+++ b/src/opencollab_mcp/tools/discovery.py
@@ -24,14 +24,16 @@ def register(mcp: FastMCP) -> None:
         },
     )
     async def opencollab_find_issues(params: LanguageInput) -> str:
-        """Find beginner-friendly open-source issues labelled 'good first
-        issue' for a given programming language. Returns up to 15 recently
-        created issues from public repos.
+        """Find open-source issues by language and difficulty.
+        Beginner searches use the "good first issue" label, while intermediate
+        searches use the "help wanted" label. Returns up to 15 recently created
+        issues from public repos.
         """
         since = recent_date_str(RECENT_ISSUES_DAYS)
+        label = 'label:"good first issue"' if params.difficulty == "beginner" else 'label:"help wanted"'
         query_parts = [
             f"language:{params.language}",
-            'label:"good first issue"',
+            label,
             "state:open",
             f"created:>{since}",
             "is:public",

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -12,6 +12,7 @@ import json
 import pytest
 
 from opencollab_mcp.server import build_server
+from opencollab_mcp.tools import discovery
 
 EXPECTED_TOOL_NAMES = {
     # Discovery (2)
@@ -125,3 +126,23 @@ async def test_check_issue_availability_invalid_number(mock_github):
     parsed = json.loads(_extract_text(result))
     assert "error" in parsed
     assert "Invalid issue_number" in parsed["error"]
+@pytest.mark.asyncio
+async def test_find_issues_intermediate_uses_help_wanted(monkeypatch):
+    captured_query = ""
+
+    async def fake_github_search(endpoint, query, params=None):
+        nonlocal captured_query
+        captured_query = query
+        return {"total_count": 0, "items": []}
+
+    monkeypatch.setattr(discovery, "github_search", fake_github_search)
+
+    server = build_server()
+    await _call_tool_compat(
+        server,
+        "opencollab_find_issues",
+        {"params": {"language": "Python", "difficulty": "intermediate"}},
+    )
+
+    assert 'label:"help wanted"' in captured_query
+    assert 'label:"good first issue"' not in captured_query


### PR DESCRIPTION
Adds a difficulty filter to `opencollab_find_issues`.

* `beginner` searches `good first issue`
* `intermediate` searches `help wanted`
* updates the README
* adds test coverage

Tested with:

* `ruff check src tests`
* `python -m pytest tests/test_tools.py tests/test_models.py -q`

14 passed.

Fixes #21