### PR TITLE
fix(deps): pin mcp<2 — 2.0.0 removed mcp.server.fastmcp, breaks every CI run

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "mcp[cli]>=1.2.0",
+    "mcp[cli]>=1.2.0,<2",  # 2.0 removed mcp.server.fastmcp; migrate before lifting
     "httpx>=0.27.0",
     "pydantic>=2.0.0",
 ]


### PR DESCRIPTION
## Problem

Every open PR (#22–#27) fails CI with the same error before a single test runs:

```
src/opencollab_mcp/server.py:15: in <module>
    from mcp.server.fastmcp import FastMCP
E   ModuleNotFoundError: No module named 'mcp.server.fastmcp'
```

`pyproject.toml` pins `mcp[cli]>=1.2.0` with no upper bound. `mcp 2.0.0` has since been released and no longer ships `mcp.server.fastmcp` (`FastMCP` moved to `mcp.server.mcpserver`). A clean runner now resolves 2.0.0 and the import fails. `main` was last green on July 5 against 1.x and would fail identically if re-run today — the PR authors did nothing wrong (#22 and #23 both flagged this in their descriptions).

## Fix

Pin `mcp[cli]>=1.2.0,<2` until the server is migrated to the 2.x API.

## Verification

Fresh venv, `pip install -e ".[dev]"` → resolves `mcp 1.29.0`:

```
ruff check src tests   # All checks passed
pytest -q              # 46 passed
```

Also verified all six open PRs merge cleanly on top of this (79 passed combined).

🤖 Generated with [Claude Code](https://claude.com/claude-code)